### PR TITLE
Allow exact AST type matching

### DIFF
--- a/Public/Get-AstObject.ps1
+++ b/Public/Get-AstObject.ps1
@@ -19,15 +19,24 @@ function Get-AstObject {
 	    [ValidateNotNullOrEmpty()]
 	    [string]$ScriptPath,
 	
-		[Parameter(Mandatory)]
+	    [Parameter(Mandatory)]
 	    [ValidateNotNullOrEmpty()]
-	    [string]$Type
+	    [string]$Type,
+
+            [Parameter()]
+            [switch]$ExactType
 	)
 	process {
 	    try {
 			[System.Type]$FullType = "System.Management.Automation.Language.$Type"
+			$astTypeFilter = if($ExactType.IsPresent){
+                            { $args[0].GetType() -eq $FullType }
+                        }
+                        else {
+                            { $args[0] -is $FullType}
+                        }
 			$ast = [System.Management.Automation.Language.Parser]::ParseFile( $ScriptPath, [ref]$null, [ref]$null )
-			$ast.FindAll( { $args[0] -is $FullType }, $true )  |
+			$ast.FindAll( $astTypeFilter, $true )  |
 				ForEach-Object {
 					$_
 				}


### PR DESCRIPTION
The `-is` operator will return true for extended/inherited types as well.
This commit allows optional exact type matching, useful for Ast types like ConstantExpressionAst