### PR TITLE
Resolved ScriptPath before passing to ParseFile function

### DIFF
--- a/Public/Get-AstObject.ps1
+++ b/Public/Get-AstObject.ps1
@@ -35,7 +35,8 @@ function Get-AstObject {
                         else {
                             { $args[0] -is $FullType}
                         }
-			$ast = [System.Management.Automation.Language.Parser]::ParseFile( $ScriptPath, [ref]$null, [ref]$null )
+			$FullPath = (Resolve-Path -Path $ScriptPath).ProviderPath
+			$ast = [System.Management.Automation.Language.Parser]::ParseFile( $FullPath, [ref]$null, [ref]$null )
 			$ast.FindAll( $astTypeFilter, $true )  |
 				ForEach-Object {
 					$_

--- a/Public/Get-AstType.ps1
+++ b/Public/Get-AstType.ps1
@@ -21,7 +21,8 @@ function Get-AstType {
 	)
 	process {
 	    try {
-			$ast = [System.Management.Automation.Language.Parser]::ParseFile( $ScriptPath, [ref]$null, [ref]$null )
+			$FullPath = (Resolve-Path -Path $ScriptPath).ProviderPath
+			$ast = [System.Management.Automation.Language.Parser]::ParseFile( $FullPath, [ref]$null, [ref]$null )
 			$ast.FindAll( { $args[0] -ne $null }, $true )  |
 				ForEach-Object {
 					$_.GetType()


### PR DESCRIPTION
Change to prevent  AST returned from ParseFile function having an empty extent in PowerShell console on Win10 version 1909 build 18363.693 with Powershell version 5.1.18362.628
Issue was not observed in Powershell ISE.
